### PR TITLE
Calendar format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,12 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [] -
 ### Changed
 - Improves backwards compatibility for Safari < 11
+- Calendar `dateheaders` shows relative date for today and tomorrow
+- `showEnd` works with all day events and `dateheaders` time format
 
+### Fixed
+- whole day events are split with UTC
+ 
 ## [2.11.0] - 2020-04-01
 
 🚨 READ THIS BEFORE UPDATING 🚨

--- a/index.html
+++ b/index.html
@@ -18,6 +18,7 @@
 	<script type="text/javascript">
 		var version = "#VERSION#";
 	</script>
+	<!-- <script src="http://192.168.178.63:1337/vorlon.js"></script> -->
 </head>
 <body>
 	<div class="region fullscreen below"><div class="container"></div></div>

--- a/modules/default/calendar/calendar.css
+++ b/modules/default/calendar/calendar.css
@@ -23,7 +23,7 @@
 
 .calendar .time {
   padding-left: 30px;
-  padding-right: 2px;
+  padding-right: 4px;
   text-align: right;
   vertical-align: top;
 }

--- a/modules/default/calendar/calendar.css
+++ b/modules/default/calendar/calendar.css
@@ -22,7 +22,7 @@
 }
 
 .calendar .time {
-  padding-left: 30px;
+  padding-left: 2px;
   padding-right: 4px;
   text-align: right;
   vertical-align: top;

--- a/modules/default/calendar/calendar.css
+++ b/modules/default/calendar/calendar.css
@@ -23,6 +23,7 @@
 
 .calendar .time {
   padding-left: 30px;
+  padding-right: 2px;
   text-align: right;
   vertical-align: top;
 }

--- a/modules/default/calendar/calendar.css
+++ b/modules/default/calendar/calendar.css
@@ -1,3 +1,7 @@
+.calendar {
+  text-align: left;
+}
+
 .calendar .symbol {
   padding-left: 0;
   padding-right: 10px;

--- a/modules/default/calendar/calendar.js
+++ b/modules/default/calendar/calendar.js
@@ -421,12 +421,14 @@ Module.register("calendar", {
 					}
 					locationRow.appendChild(endTimeCell);
 				}
-				if (event.location !== false) {
+				if (event.location && !event.fullDayEvent) {
 					var descCell = document.createElement("td");
 					descCell.className = "location";
-					descCell.colSpan = "1";
+					descCell.colSpan = "2";
 					descCell.innerHTML = event.location;
 					locationRow.appendChild(descCell);
+				} else if (event.location) {
+					descCell.colSpan = "1";
 				}
 
 				wrapper.appendChild(locationRow);

--- a/modules/default/calendar/calendar.js
+++ b/modules/default/calendar/calendar.js
@@ -410,7 +410,8 @@ Module.register("calendar", {
 					if ((this.config.urgency > 1) && (event.startDate - now < (this.config.urgency * oneDay))) {
 						// This event falls within the config.urgency period that the user has set
 						if(event.fullDayEvent) {
-							endTimeCell.innerHTML += this.translate("ALL_DAY");
+							// do not show
+							// endTimeCell.innerHTML += this.translate("ALL_DAY");
 						} else {
 							endTimeCell.innerHTML += "->";
 							endTimeCell.innerHTML += this.capFirst(moment(event.endDate, "x").format('HH:mm'));

--- a/modules/default/calendar/calendar.js
+++ b/modules/default/calendar/calendar.js
@@ -409,12 +409,12 @@ Module.register("calendar", {
 					endTimeCell.colSpan = "1";
 					if ((this.config.urgency > 1) && (event.startDate - now < (this.config.urgency * oneDay))) {
 						// This event falls within the config.urgency period that the user has set
-						if(event.fullDayEvent) {
+						if (event.fullDayEvent) {
 							// do not show
 							// endTimeCell.innerHTML += this.translate("ALL_DAY");
 						} else {
 							endTimeCell.innerHTML += "->";
-							endTimeCell.innerHTML += this.capFirst(moment(event.endDate, "x").format('HH:mm'));
+							endTimeCell.innerHTML += this.capFirst(moment(event.endDate, "x").format("HH:mm"));
 						}
 					} else {
 						endTimeCell.innerHTML += this.capFirst(moment(event.endDate, "x").format(this.config.fullDayEventDateFormat));
@@ -438,10 +438,10 @@ Module.register("calendar", {
 					locationRow.style.opacity = 1 - (1 / fadeSteps * currentFadeStep);
 				}
 			}
-	}
+		}
 
 		return wrapper;
-},
+	},
 
 	/**
 	 * This function accepts a number (either 12 or 24) and returns a moment.js LocaleSpecification with the
@@ -453,18 +453,18 @@ Module.register("calendar", {
 	 */
 	getLocaleSpecification: function (timeFormat) {
 		switch (timeFormat) {
-			case 12: {
-				return { longDateFormat: { LT: "h:mm A" } };
-				break;
-			}
-			case 24: {
-				return { longDateFormat: { LT: "HH:mm" } };
-				break;
-			}
-			default: {
-				return { longDateFormat: { LT: moment.localeData().longDateFormat("LT") } };
-				break;
-			}
+		case 12: {
+			return { longDateFormat: { LT: "h:mm A" } };
+			break;
+		}
+		case 24: {
+			return { longDateFormat: { LT: "HH:mm" } };
+			break;
+		}
+		default: {
+			return { longDateFormat: { LT: moment.localeData().longDateFormat("LT") } };
+			break;
+		}
 		}
 	},
 
@@ -498,7 +498,7 @@ Module.register("calendar", {
 		var future = moment().startOf("day").add(this.config.maximumNumberOfDays, "days").toDate();
 		for (var c in this.calendarData) {
 			var calendar = this.calendarData[c];
-			
+
 			for (var e in calendar) {
 				var event = JSON.parse(JSON.stringify(calendar[e])); // clone object
 
@@ -567,13 +567,13 @@ Module.register("calendar", {
 		return events.slice(0, this.config.maximumEntries);
 	},
 
-	isTomorrow: function(startDate) {
+	isTomorrow: function (startDate) {
 		const start = moment(startDate, "x");
 		const now = moment(new Date());
 
-		return start.get("year") === now.get("year") 
-			&& start.get("month") === now.get("month") 
-			&& start.get("date") === now.get("date")+1
+		return start.get("year") === now.get("year")
+			&& start.get("month") === now.get("month")
+			&& start.get("date") === now.get("date") + 1;
 	},
 
 	listContainsEvent: function (eventList, event) {

--- a/modules/default/calendar/calendar.js
+++ b/modules/default/calendar/calendar.js
@@ -405,7 +405,7 @@ Module.register("calendar", {
 
 				if (this.config.showEnd) {
 					var endTimeCell = document.createElement("td");
-					endTimeCell.className = "";
+					endTimeCell.className = "time";
 					endTimeCell.colSpan = "1";
 					if ((this.config.urgency > 1) && (event.startDate - now < (this.config.urgency * oneDay))) {
 						// This event falls within the config.urgency period that the user has set

--- a/modules/default/calendar/calendar.js
+++ b/modules/default/calendar/calendar.js
@@ -547,7 +547,7 @@ Module.register("calendar", {
 						midnightUtc = moment(midnightUtc, "x").add(1, "day").format("x"); // next day
 					}
 					// Last day
-					event.title += " (" + count + "/" + maxCount + ")";
+					// event.title += " (" + count + "/" + maxCount + ")";
 					splitEvents.push(event);
 
 					for (event of splitEvents) {

--- a/translations/de.json
+++ b/translations/de.json
@@ -1,6 +1,7 @@
 {
 	"LOADING": "Lade &hellip;",
 
+	"ALL_DAY": "Ganztägig",
 	"TODAY": "Heute",
 	"TOMORROW": "Morgen",
 	"DAYAFTERTOMORROW": "&Uuml;bermorgen",

--- a/translations/en.json
+++ b/translations/en.json
@@ -1,6 +1,7 @@
 {
 	"LOADING": "Loading &hellip;",
 
+	"ALL_DAY": "All day",
 	"TODAY": "Today",
 	"TOMORROW": "Tomorrow",
 	"DAYAFTERTOMORROW": "In 2 days",


### PR DESCRIPTION
Allow when calendar format is set to `dataheaders` the dates for today and tomorrow are shown in relative time format. Furthermore, when `showEnd` is set it is shown in the "location" row of the calendar. Finally, splitting full day events using UTC to split events correctly.